### PR TITLE
Fix: GTM workflows run in projects/products/endless-molt

### DIFF
--- a/.github/workflows/gtm-autonomous.yml
+++ b/.github/workflows/gtm-autonomous.yml
@@ -12,6 +12,9 @@ jobs:
     permissions:
       contents: read
       issues: write
+    defaults:
+      run:
+        working-directory: projects/products/endless-molt
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -21,6 +24,7 @@ jobs:
         with:
           node-version: "20"
           cache: "npm"
+          cache-dependency-path: projects/products/endless-molt/package-lock.json
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/gtm-keep-going.yml
+++ b/.github/workflows/gtm-keep-going.yml
@@ -12,6 +12,9 @@ jobs:
     permissions:
       contents: read
       issues: write
+    defaults:
+      run:
+        working-directory: projects/products/endless-molt
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -21,6 +24,7 @@ jobs:
         with:
           node-version: "20"
           cache: "npm"
+          cache-dependency-path: projects/products/endless-molt/package-lock.json
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/prod-monitor.yml
+++ b/.github/workflows/prod-monitor.yml
@@ -12,6 +12,9 @@ jobs:
     permissions:
       contents: read
       issues: write
+    defaults:
+      run:
+        working-directory: projects/products/endless-molt
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -21,6 +24,7 @@ jobs:
         with:
           node-version: "20"
           cache: "npm"
+          cache-dependency-path: projects/products/endless-molt/package-lock.json
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/social-autonomous.yml
+++ b/.github/workflows/social-autonomous.yml
@@ -12,6 +12,9 @@ jobs:
     permissions:
       contents: read
       issues: write
+    defaults:
+      run:
+        working-directory: projects/products/endless-molt
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -21,6 +24,7 @@ jobs:
         with:
           node-version: "20"
           cache: "npm"
+          cache-dependency-path: projects/products/endless-molt/package-lock.json
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
Sets workflow working-directory + npm cache-dependency-path so scheduled GTM scripts run against the Endless Molt package.json.