### PR TITLE
Fix: GTM scripts accept quoted DATABASE_URL

### DIFF
--- a/projects/products/endless-molt/scripts/first-sale-sprint.mjs
+++ b/projects/products/endless-molt/scripts/first-sale-sprint.mjs
@@ -46,6 +46,10 @@ function parseIntEnv(name, fallback, min, max) {
   return Math.max(min, Math.min(max, value));
 }
 
+function stripWrappingQuotes(value) {
+  return String(value || '').trim().replace(/^['"]+|['"]+$/g, '');
+}
+
 function toSqliteDatetime(date) {
   return date.toISOString().slice(0, 19).replace('T', ' ');
 }
@@ -461,7 +465,7 @@ class PostgresStore {
 }
 
 async function openStore() {
-  const databaseUrl = process.env.DATABASE_URL || '';
+  const databaseUrl = stripWrappingQuotes(process.env.DATABASE_URL);
   if (databaseUrl.startsWith('postgres://') || databaseUrl.startsWith('postgresql://')) {
     const store = new PostgresStore(databaseUrl);
     await store.connect();

--- a/projects/products/endless-molt/scripts/gtm-autonomous.mjs
+++ b/projects/products/endless-molt/scripts/gtm-autonomous.mjs
@@ -20,6 +20,10 @@ const actionQueuePath = path.join(outputDir, 'action-queue.json');
 const githubRepo = process.env.GTM_GITHUB_REPO || '';
 const githubToken = process.env.GTM_GITHUB_TOKEN || '';
 
+function stripWrappingQuotes(value) {
+  return String(value || '').trim().replace(/^['"]+|['"]+$/g, '');
+}
+
 function parseTimestamp(value) {
   if (!value) return null;
   if (value instanceof Date) return value;
@@ -223,7 +227,7 @@ function loadDataFromSqlite(filePath) {
 }
 
 async function loadData() {
-  const databaseUrl = process.env.DATABASE_URL || '';
+  const databaseUrl = stripWrappingQuotes(process.env.DATABASE_URL);
   if (databaseUrl.startsWith('postgres://') || databaseUrl.startsWith('postgresql://')) {
     return loadDataFromPostgres(databaseUrl);
   }

--- a/projects/products/endless-molt/scripts/social-autonomous.mjs
+++ b/projects/products/endless-molt/scripts/social-autonomous.mjs
@@ -42,6 +42,10 @@ function parseIntEnv(name, fallback, min, max) {
   return Math.max(min, Math.min(max, value));
 }
 
+function stripWrappingQuotes(value) {
+  return String(value || '').trim().replace(/^['"]+|['"]+$/g, '');
+}
+
 function toSqliteDatetime(date) {
   return date.toISOString().slice(0, 19).replace('T', ' ');
 }
@@ -853,7 +857,7 @@ async function maybeCreateGithubIssue(reportMarkdown, resultSummary) {
 }
 
 async function createStore() {
-  const databaseUrl = process.env.DATABASE_URL || '';
+  const databaseUrl = stripWrappingQuotes(process.env.DATABASE_URL);
   if (databaseUrl.startsWith('postgres://') || databaseUrl.startsWith('postgresql://')) {
     const store = new PostgresStore(databaseUrl);
     await store.connect();


### PR DESCRIPTION
GTM scripts were falling back to SQLite in CI when DATABASE_URL was quoted, then failing because endless-molt.db is not present. This strips wrapping quotes before backend detection.