### PR TITLE
Fix CI: recognize Postgres DATABASE_URL

### DIFF
--- a/projects/products/endless-molt/scripts/first-sale-sprint.mjs
+++ b/projects/products/endless-molt/scripts/first-sale-sprint.mjs
@@ -50,6 +50,10 @@ function stripWrappingQuotes(value) {
   return String(value || '').trim().replace(/^['"]+|['"]+$/g, '');
 }
 
+function isPostgresUrl(value) {
+  return /^(postgres|postgresql):/i.test(String(value || '').trim());
+}
+
 function toSqliteDatetime(date) {
   return date.toISOString().slice(0, 19).replace('T', ' ');
 }
@@ -466,7 +470,7 @@ class PostgresStore {
 
 async function openStore() {
   const databaseUrl = stripWrappingQuotes(process.env.DATABASE_URL);
-  if (databaseUrl.startsWith('postgres://') || databaseUrl.startsWith('postgresql://')) {
+  if (isPostgresUrl(databaseUrl)) {
     const store = new PostgresStore(databaseUrl);
     await store.connect();
     return { source: 'postgres', store };

--- a/projects/products/endless-molt/scripts/gtm-autonomous.mjs
+++ b/projects/products/endless-molt/scripts/gtm-autonomous.mjs
@@ -24,6 +24,10 @@ function stripWrappingQuotes(value) {
   return String(value || '').trim().replace(/^['"]+|['"]+$/g, '');
 }
 
+function isPostgresUrl(value) {
+  return /^(postgres|postgresql):/i.test(String(value || '').trim());
+}
+
 function parseTimestamp(value) {
   if (!value) return null;
   if (value instanceof Date) return value;
@@ -228,7 +232,7 @@ function loadDataFromSqlite(filePath) {
 
 async function loadData() {
   const databaseUrl = stripWrappingQuotes(process.env.DATABASE_URL);
-  if (databaseUrl.startsWith('postgres://') || databaseUrl.startsWith('postgresql://')) {
+  if (isPostgresUrl(databaseUrl)) {
     return loadDataFromPostgres(databaseUrl);
   }
 

--- a/projects/products/endless-molt/scripts/social-autonomous.mjs
+++ b/projects/products/endless-molt/scripts/social-autonomous.mjs
@@ -46,6 +46,10 @@ function stripWrappingQuotes(value) {
   return String(value || '').trim().replace(/^['"]+|['"]+$/g, '');
 }
 
+function isPostgresUrl(value) {
+  return /^(postgres|postgresql):/i.test(String(value || '').trim());
+}
+
 function toSqliteDatetime(date) {
   return date.toISOString().slice(0, 19).replace('T', ' ');
 }
@@ -858,7 +862,7 @@ async function maybeCreateGithubIssue(reportMarkdown, resultSummary) {
 
 async function createStore() {
   const databaseUrl = stripWrappingQuotes(process.env.DATABASE_URL);
-  if (databaseUrl.startsWith('postgres://') || databaseUrl.startsWith('postgresql://')) {
+  if (isPostgresUrl(databaseUrl)) {
     const store = new PostgresStore(databaseUrl);
     await store.connect();
     return { source: 'postgres', store };


### PR DESCRIPTION
GTM workflows were falling back to sqlite in CI (no local db file), causing "unable to open database file".\n\nThis patch makes Postgres detection tolerant of case/format via a small regex helper in:\n- projects/products/endless-molt/scripts/gtm-autonomous.mjs\n- projects/products/endless-molt/scripts/social-autonomous.mjs\n- projects/products/endless-molt/scripts/first-sale-sprint.mjs\n\nExpected: Autonomous GTM + Social GTM actions connect to Postgres when DATABASE_URL is set to a postgres/postgresql URL.