### PR TITLE
Fix CI: normalize DATABASE_URL (and fail clearly if not Postgres)

### DIFF
--- a/projects/products/endless-molt/scripts/first-sale-sprint.mjs
+++ b/projects/products/endless-molt/scripts/first-sale-sprint.mjs
@@ -46,12 +46,30 @@ function parseIntEnv(name, fallback, min, max) {
   return Math.max(min, Math.min(max, value));
 }
 
-function stripWrappingQuotes(value) {
-  return String(value || '').trim().replace(/^['"]+|['"]+$/g, '');
+function normalizeDatabaseUrl(value) {
+  let url = String(value || '').trim();
+
+  // Copy/paste can introduce invisible characters (for example zero-width spaces) or
+  // escaped quoting (`\"...\"`) that break simple protocol checks.
+  url = url.replace(/^[^A-Za-z]+/, '');
+  url = url.replace(/^['"`]+|['"`]+$/g, '');
+  url = url.replace(/^\\+/, '').replace(/\\+$/, '');
+  url = url.replace(/^jdbc:/i, '');
+  url = url.replace(/^postgresql\\+[^:]+:/i, 'postgresql:');
+  url = url.replace(/^postgres\\+[^:]+:/i, 'postgres:');
+
+  return url;
+}
+
+function getUrlScheme(value) {
+  const url = normalizeDatabaseUrl(value);
+  const match = url.match(/^([a-zA-Z][a-zA-Z0-9+.-]*):/);
+  return match ? match[1].toLowerCase() : '';
 }
 
 function isPostgresUrl(value) {
-  return /^(postgres|postgresql):/i.test(String(value || '').trim());
+  const scheme = getUrlScheme(value);
+  return scheme === 'postgres' || scheme === 'postgresql';
 }
 
 function toSqliteDatetime(date) {
@@ -469,7 +487,9 @@ class PostgresStore {
 }
 
 async function openStore() {
-  const databaseUrl = stripWrappingQuotes(process.env.DATABASE_URL);
+  const databaseUrlRaw = process.env.DATABASE_URL;
+  const databaseUrl = normalizeDatabaseUrl(databaseUrlRaw);
+  const scheme = getUrlScheme(databaseUrlRaw);
   if (isPostgresUrl(databaseUrl)) {
     const store = new PostgresStore(databaseUrl);
     await store.connect();
@@ -477,6 +497,13 @@ async function openStore() {
   }
 
   const sqlitePath = path.join(process.cwd(), 'database', 'endless-molt.db');
+  try {
+    await fs.access(sqlitePath);
+  } catch {
+    throw new Error(
+      `First-sale sprint requires a Postgres DATABASE_URL in CI. Got scheme=${scheme || 'unknown'}; sqlite file missing at ${sqlitePath}.`,
+    );
+  }
   return { source: `sqlite:${sqlitePath}`, store: new SqliteStore(sqlitePath) };
 }
 

--- a/projects/products/endless-molt/scripts/gtm-autonomous.mjs
+++ b/projects/products/endless-molt/scripts/gtm-autonomous.mjs
@@ -20,12 +20,30 @@ const actionQueuePath = path.join(outputDir, 'action-queue.json');
 const githubRepo = process.env.GTM_GITHUB_REPO || '';
 const githubToken = process.env.GTM_GITHUB_TOKEN || '';
 
-function stripWrappingQuotes(value) {
-  return String(value || '').trim().replace(/^['"]+|['"]+$/g, '');
+function normalizeDatabaseUrl(value) {
+  let url = String(value || '').trim();
+
+  // Copy/paste can introduce invisible characters (for example zero-width spaces) or
+  // escaped quoting (`\"...\"`) that break simple protocol checks.
+  url = url.replace(/^[^A-Za-z]+/, '');
+  url = url.replace(/^['"`]+|['"`]+$/g, '');
+  url = url.replace(/^\\+/, '').replace(/\\+$/, '');
+  url = url.replace(/^jdbc:/i, '');
+  url = url.replace(/^postgresql\\+[^:]+:/i, 'postgresql:');
+  url = url.replace(/^postgres\\+[^:]+:/i, 'postgres:');
+
+  return url;
+}
+
+function getUrlScheme(value) {
+  const url = normalizeDatabaseUrl(value);
+  const match = url.match(/^([a-zA-Z][a-zA-Z0-9+.-]*):/);
+  return match ? match[1].toLowerCase() : '';
 }
 
 function isPostgresUrl(value) {
-  return /^(postgres|postgresql):/i.test(String(value || '').trim());
+  const scheme = getUrlScheme(value);
+  return scheme === 'postgres' || scheme === 'postgresql';
 }
 
 function parseTimestamp(value) {
@@ -231,12 +249,22 @@ function loadDataFromSqlite(filePath) {
 }
 
 async function loadData() {
-  const databaseUrl = stripWrappingQuotes(process.env.DATABASE_URL);
+  const databaseUrlRaw = process.env.DATABASE_URL;
+  const databaseUrl = normalizeDatabaseUrl(databaseUrlRaw);
+  const scheme = getUrlScheme(databaseUrlRaw);
+
   if (isPostgresUrl(databaseUrl)) {
     return loadDataFromPostgres(databaseUrl);
   }
 
   const defaultSqlitePath = path.join(process.cwd(), 'database', 'endless-molt.db');
+  try {
+    await fs.access(defaultSqlitePath);
+  } catch {
+    throw new Error(
+      `Autonomous GTM requires a Postgres DATABASE_URL in CI. Got scheme=${scheme || 'unknown'}; sqlite file missing at ${defaultSqlitePath}.`,
+    );
+  }
   return loadDataFromSqlite(defaultSqlitePath);
 }
 

--- a/projects/products/endless-molt/scripts/social-autonomous.mjs
+++ b/projects/products/endless-molt/scripts/social-autonomous.mjs
@@ -42,12 +42,30 @@ function parseIntEnv(name, fallback, min, max) {
   return Math.max(min, Math.min(max, value));
 }
 
-function stripWrappingQuotes(value) {
-  return String(value || '').trim().replace(/^['"]+|['"]+$/g, '');
+function normalizeDatabaseUrl(value) {
+  let url = String(value || '').trim();
+
+  // Copy/paste can introduce invisible characters (for example zero-width spaces) or
+  // escaped quoting (`\"...\"`) that break simple protocol checks.
+  url = url.replace(/^[^A-Za-z]+/, '');
+  url = url.replace(/^['"`]+|['"`]+$/g, '');
+  url = url.replace(/^\\+/, '').replace(/\\+$/, '');
+  url = url.replace(/^jdbc:/i, '');
+  url = url.replace(/^postgresql\\+[^:]+:/i, 'postgresql:');
+  url = url.replace(/^postgres\\+[^:]+:/i, 'postgres:');
+
+  return url;
+}
+
+function getUrlScheme(value) {
+  const url = normalizeDatabaseUrl(value);
+  const match = url.match(/^([a-zA-Z][a-zA-Z0-9+.-]*):/);
+  return match ? match[1].toLowerCase() : '';
 }
 
 function isPostgresUrl(value) {
-  return /^(postgres|postgresql):/i.test(String(value || '').trim());
+  const scheme = getUrlScheme(value);
+  return scheme === 'postgres' || scheme === 'postgresql';
 }
 
 function toSqliteDatetime(date) {
@@ -861,7 +879,9 @@ async function maybeCreateGithubIssue(reportMarkdown, resultSummary) {
 }
 
 async function createStore() {
-  const databaseUrl = stripWrappingQuotes(process.env.DATABASE_URL);
+  const databaseUrlRaw = process.env.DATABASE_URL;
+  const databaseUrl = normalizeDatabaseUrl(databaseUrlRaw);
+  const scheme = getUrlScheme(databaseUrlRaw);
   if (isPostgresUrl(databaseUrl)) {
     const store = new PostgresStore(databaseUrl);
     await store.connect();
@@ -869,6 +889,13 @@ async function createStore() {
   }
 
   const sqlitePath = process.env.DATABASE_PATH || path.join(process.cwd(), 'database', 'endless-molt.db');
+  try {
+    await fs.access(sqlitePath);
+  } catch {
+    throw new Error(
+      `Autonomous social GTM requires a Postgres DATABASE_URL in CI. Got scheme=${scheme || 'unknown'}; sqlite file missing at ${sqlitePath}.`,
+    );
+  }
   return { source: `sqlite:${sqlitePath}`, store: new SqliteStore(sqlitePath) };
 }
 


### PR DESCRIPTION
CI was still falling back to sqlite ("unable to open database file") even with DATABASE_URL set.\n\nThis change:\n- Normalizes DATABASE_URL (handles copy/paste junk, JDBC prefix, SQLAlchemy-style postgresql+... schemes).\n- Adds a clear error when the sqlite fallback file is missing, including the detected URL scheme (no secret leakage).\n\nAffected scripts:\n- projects/products/endless-molt/scripts/gtm-autonomous.mjs\n- projects/products/endless-molt/scripts/social-autonomous.mjs\n- projects/products/endless-molt/scripts/first-sale-sprint.mjs