### PR TITLE
Fix: handle DATABASE_URL=... secrets in CI

### DIFF
--- a/projects/products/endless-molt/scripts/first-sale-sprint.mjs
+++ b/projects/products/endless-molt/scripts/first-sale-sprint.mjs
@@ -49,6 +49,17 @@ function parseIntEnv(name, fallback, min, max) {
 function normalizeDatabaseUrl(value) {
   let url = String(value || '').trim();
 
+  // Common copy/paste mistake: pasting `DATABASE_URL=...` instead of the URL itself.
+  const eqIndex = url.indexOf('=');
+  const colonIndex = url.indexOf(':');
+  if (eqIndex !== -1 && (colonIndex === -1 || eqIndex < colonIndex)) {
+    const candidate = url.slice(eqIndex + 1).trim();
+    const candidateProbe = candidate.replace(/^[^A-Za-z]+/, '');
+    if (/^[A-Za-z][A-Za-z0-9+.-]*:/.test(candidateProbe)) {
+      url = candidate;
+    }
+  }
+
   // Copy/paste can introduce invisible characters (for example zero-width spaces) or
   // escaped quoting (`\"...\"`) that break simple protocol checks.
   url = url.replace(/^[^A-Za-z]+/, '');

--- a/projects/products/endless-molt/scripts/first-sale-sprint.mjs
+++ b/projects/products/endless-molt/scripts/first-sale-sprint.mjs
@@ -46,12 +46,30 @@ function parseIntEnv(name, fallback, min, max) {
   return Math.max(min, Math.min(max, value));
 }
 
-function stripWrappingQuotes(value) {
-  return String(value || '').trim().replace(/^['"]+|['"]+$/g, '');
+function normalizeDatabaseUrl(value) {
+  let url = String(value || '').trim();
+
+  // Copy/paste can introduce invisible characters (for example zero-width spaces) or
+  // escaped quoting (`\"...\"`) that break simple protocol checks.
+  url = url.replace(/^[^A-Za-z]+/, '');
+  url = url.replace(/^['"`]+|['"`]+$/g, '');
+  url = url.replace(/^\\+/, '').replace(/\\+$/, '');
+  url = url.replace(/^jdbc:/i, '');
+  url = url.replace(/^postgresql\\+[^:]+:/i, 'postgresql:');
+  url = url.replace(/^postgres\\+[^:]+:/i, 'postgres:');
+
+  return url;
+}
+
+function getUrlScheme(value) {
+  const url = normalizeDatabaseUrl(value);
+  const match = url.match(/^([a-zA-Z][a-zA-Z0-9+.-]*):/);
+  return match ? match[1].toLowerCase() : '';
 }
 
 function isPostgresUrl(value) {
-  return /^(postgres|postgresql):/i.test(String(value || '').trim());
+  const scheme = getUrlScheme(value);
+  return scheme === 'postgres' || scheme === 'postgresql';
 }
 
 function toSqliteDatetime(date) {
@@ -469,7 +487,9 @@ class PostgresStore {
 }
 
 async function openStore() {
-  const databaseUrl = stripWrappingQuotes(process.env.DATABASE_URL);
+  const databaseUrlRaw = process.env.DATABASE_URL;
+  const databaseUrl = normalizeDatabaseUrl(databaseUrlRaw);
+  const scheme = getUrlScheme(databaseUrlRaw);
   if (isPostgresUrl(databaseUrl)) {
     const store = new PostgresStore(databaseUrl);
     await store.connect();
@@ -477,6 +497,13 @@ async function openStore() {
   }
 
   const sqlitePath = path.join(process.cwd(), 'database', 'endless-molt.db');
+  try {
+    await fs.access(sqlitePath);
+  } catch {
+    throw new Error(
+      `First-sale sprint requires a Postgres DATABASE_URL in CI. Got scheme=${scheme || 'unknown'}; sqlite file missing at ${sqlitePath}.`,
+    );
+  }
   return { source: `sqlite:${sqlitePath}`, store: new SqliteStore(sqlitePath) };
 }
 

--- a/projects/products/endless-molt/scripts/gtm-autonomous.mjs
+++ b/projects/products/endless-molt/scripts/gtm-autonomous.mjs
@@ -20,12 +20,30 @@ const actionQueuePath = path.join(outputDir, 'action-queue.json');
 const githubRepo = process.env.GTM_GITHUB_REPO || '';
 const githubToken = process.env.GTM_GITHUB_TOKEN || '';
 
-function stripWrappingQuotes(value) {
-  return String(value || '').trim().replace(/^['"]+|['"]+$/g, '');
+function normalizeDatabaseUrl(value) {
+  let url = String(value || '').trim();
+
+  // Copy/paste can introduce invisible characters (for example zero-width spaces) or
+  // escaped quoting (`\"...\"`) that break simple protocol checks.
+  url = url.replace(/^[^A-Za-z]+/, '');
+  url = url.replace(/^['"`]+|['"`]+$/g, '');
+  url = url.replace(/^\\+/, '').replace(/\\+$/, '');
+  url = url.replace(/^jdbc:/i, '');
+  url = url.replace(/^postgresql\\+[^:]+:/i, 'postgresql:');
+  url = url.replace(/^postgres\\+[^:]+:/i, 'postgres:');
+
+  return url;
+}
+
+function getUrlScheme(value) {
+  const url = normalizeDatabaseUrl(value);
+  const match = url.match(/^([a-zA-Z][a-zA-Z0-9+.-]*):/);
+  return match ? match[1].toLowerCase() : '';
 }
 
 function isPostgresUrl(value) {
-  return /^(postgres|postgresql):/i.test(String(value || '').trim());
+  const scheme = getUrlScheme(value);
+  return scheme === 'postgres' || scheme === 'postgresql';
 }
 
 function parseTimestamp(value) {
@@ -231,12 +249,22 @@ function loadDataFromSqlite(filePath) {
 }
 
 async function loadData() {
-  const databaseUrl = stripWrappingQuotes(process.env.DATABASE_URL);
+  const databaseUrlRaw = process.env.DATABASE_URL;
+  const databaseUrl = normalizeDatabaseUrl(databaseUrlRaw);
+  const scheme = getUrlScheme(databaseUrlRaw);
+
   if (isPostgresUrl(databaseUrl)) {
     return loadDataFromPostgres(databaseUrl);
   }
 
   const defaultSqlitePath = path.join(process.cwd(), 'database', 'endless-molt.db');
+  try {
+    await fs.access(defaultSqlitePath);
+  } catch {
+    throw new Error(
+      `Autonomous GTM requires a Postgres DATABASE_URL in CI. Got scheme=${scheme || 'unknown'}; sqlite file missing at ${defaultSqlitePath}.`,
+    );
+  }
   return loadDataFromSqlite(defaultSqlitePath);
 }
 

--- a/projects/products/endless-molt/scripts/gtm-autonomous.mjs
+++ b/projects/products/endless-molt/scripts/gtm-autonomous.mjs
@@ -23,6 +23,17 @@ const githubToken = process.env.GTM_GITHUB_TOKEN || '';
 function normalizeDatabaseUrl(value) {
   let url = String(value || '').trim();
 
+  // Common copy/paste mistake: pasting `DATABASE_URL=...` instead of the URL itself.
+  const eqIndex = url.indexOf('=');
+  const colonIndex = url.indexOf(':');
+  if (eqIndex !== -1 && (colonIndex === -1 || eqIndex < colonIndex)) {
+    const candidate = url.slice(eqIndex + 1).trim();
+    const candidateProbe = candidate.replace(/^[^A-Za-z]+/, '');
+    if (/^[A-Za-z][A-Za-z0-9+.-]*:/.test(candidateProbe)) {
+      url = candidate;
+    }
+  }
+
   // Copy/paste can introduce invisible characters (for example zero-width spaces) or
   // escaped quoting (`\"...\"`) that break simple protocol checks.
   url = url.replace(/^[^A-Za-z]+/, '');

--- a/projects/products/endless-molt/scripts/social-autonomous.mjs
+++ b/projects/products/endless-molt/scripts/social-autonomous.mjs
@@ -45,6 +45,17 @@ function parseIntEnv(name, fallback, min, max) {
 function normalizeDatabaseUrl(value) {
   let url = String(value || '').trim();
 
+  // Common copy/paste mistake: pasting `DATABASE_URL=...` instead of the URL itself.
+  const eqIndex = url.indexOf('=');
+  const colonIndex = url.indexOf(':');
+  if (eqIndex !== -1 && (colonIndex === -1 || eqIndex < colonIndex)) {
+    const candidate = url.slice(eqIndex + 1).trim();
+    const candidateProbe = candidate.replace(/^[^A-Za-z]+/, '');
+    if (/^[A-Za-z][A-Za-z0-9+.-]*:/.test(candidateProbe)) {
+      url = candidate;
+    }
+  }
+
   // Copy/paste can introduce invisible characters (for example zero-width spaces) or
   // escaped quoting (`\"...\"`) that break simple protocol checks.
   url = url.replace(/^[^A-Za-z]+/, '');

--- a/projects/products/endless-molt/scripts/social-autonomous.mjs
+++ b/projects/products/endless-molt/scripts/social-autonomous.mjs
@@ -42,12 +42,30 @@ function parseIntEnv(name, fallback, min, max) {
   return Math.max(min, Math.min(max, value));
 }
 
-function stripWrappingQuotes(value) {
-  return String(value || '').trim().replace(/^['"]+|['"]+$/g, '');
+function normalizeDatabaseUrl(value) {
+  let url = String(value || '').trim();
+
+  // Copy/paste can introduce invisible characters (for example zero-width spaces) or
+  // escaped quoting (`\"...\"`) that break simple protocol checks.
+  url = url.replace(/^[^A-Za-z]+/, '');
+  url = url.replace(/^['"`]+|['"`]+$/g, '');
+  url = url.replace(/^\\+/, '').replace(/\\+$/, '');
+  url = url.replace(/^jdbc:/i, '');
+  url = url.replace(/^postgresql\\+[^:]+:/i, 'postgresql:');
+  url = url.replace(/^postgres\\+[^:]+:/i, 'postgres:');
+
+  return url;
+}
+
+function getUrlScheme(value) {
+  const url = normalizeDatabaseUrl(value);
+  const match = url.match(/^([a-zA-Z][a-zA-Z0-9+.-]*):/);
+  return match ? match[1].toLowerCase() : '';
 }
 
 function isPostgresUrl(value) {
-  return /^(postgres|postgresql):/i.test(String(value || '').trim());
+  const scheme = getUrlScheme(value);
+  return scheme === 'postgres' || scheme === 'postgresql';
 }
 
 function toSqliteDatetime(date) {
@@ -861,7 +879,9 @@ async function maybeCreateGithubIssue(reportMarkdown, resultSummary) {
 }
 
 async function createStore() {
-  const databaseUrl = stripWrappingQuotes(process.env.DATABASE_URL);
+  const databaseUrlRaw = process.env.DATABASE_URL;
+  const databaseUrl = normalizeDatabaseUrl(databaseUrlRaw);
+  const scheme = getUrlScheme(databaseUrlRaw);
   if (isPostgresUrl(databaseUrl)) {
     const store = new PostgresStore(databaseUrl);
     await store.connect();
@@ -869,6 +889,13 @@ async function createStore() {
   }
 
   const sqlitePath = process.env.DATABASE_PATH || path.join(process.cwd(), 'database', 'endless-molt.db');
+  try {
+    await fs.access(sqlitePath);
+  } catch {
+    throw new Error(
+      `Autonomous social GTM requires a Postgres DATABASE_URL in CI. Got scheme=${scheme || 'unknown'}; sqlite file missing at ${sqlitePath}.`,
+    );
+  }
   return { source: `sqlite:${sqlitePath}`, store: new SqliteStore(sqlitePath) };
 }
 


### PR DESCRIPTION
Autonomous GTM actions still fell back to sqlite with DATABASE_URL set. The new error output shows the scheme as 'unknown', which happens if the secret value accidentally includes the key prefix (e.g. ).\n\nThis patch strips a leading  prefix when it appears before the first ':' so the scripts correctly detect Postgres in CI.