### PR TITLE
Fix CI: strip KEY= prefix from DATABASE_URL

### DIFF
--- a/projects/products/endless-molt/scripts/first-sale-sprint.mjs
+++ b/projects/products/endless-molt/scripts/first-sale-sprint.mjs
@@ -49,6 +49,17 @@ function parseIntEnv(name, fallback, min, max) {
 function normalizeDatabaseUrl(value) {
   let url = String(value || '').trim();
 
+  // Common copy/paste mistake: pasting `DATABASE_URL=...` instead of the URL itself.
+  const eqIndex = url.indexOf('=');
+  const colonIndex = url.indexOf(':');
+  if (eqIndex !== -1 && (colonIndex === -1 || eqIndex < colonIndex)) {
+    const candidate = url.slice(eqIndex + 1).trim();
+    const candidateProbe = candidate.replace(/^[^A-Za-z]+/, '');
+    if (/^[A-Za-z][A-Za-z0-9+.-]*:/.test(candidateProbe)) {
+      url = candidate;
+    }
+  }
+
   // Copy/paste can introduce invisible characters (for example zero-width spaces) or
   // escaped quoting (`\"...\"`) that break simple protocol checks.
   url = url.replace(/^[^A-Za-z]+/, '');

--- a/projects/products/endless-molt/scripts/gtm-autonomous.mjs
+++ b/projects/products/endless-molt/scripts/gtm-autonomous.mjs
@@ -23,6 +23,17 @@ const githubToken = process.env.GTM_GITHUB_TOKEN || '';
 function normalizeDatabaseUrl(value) {
   let url = String(value || '').trim();
 
+  // Common copy/paste mistake: pasting `DATABASE_URL=...` instead of the URL itself.
+  const eqIndex = url.indexOf('=');
+  const colonIndex = url.indexOf(':');
+  if (eqIndex !== -1 && (colonIndex === -1 || eqIndex < colonIndex)) {
+    const candidate = url.slice(eqIndex + 1).trim();
+    const candidateProbe = candidate.replace(/^[^A-Za-z]+/, '');
+    if (/^[A-Za-z][A-Za-z0-9+.-]*:/.test(candidateProbe)) {
+      url = candidate;
+    }
+  }
+
   // Copy/paste can introduce invisible characters (for example zero-width spaces) or
   // escaped quoting (`\"...\"`) that break simple protocol checks.
   url = url.replace(/^[^A-Za-z]+/, '');

--- a/projects/products/endless-molt/scripts/social-autonomous.mjs
+++ b/projects/products/endless-molt/scripts/social-autonomous.mjs
@@ -45,6 +45,17 @@ function parseIntEnv(name, fallback, min, max) {
 function normalizeDatabaseUrl(value) {
   let url = String(value || '').trim();
 
+  // Common copy/paste mistake: pasting `DATABASE_URL=...` instead of the URL itself.
+  const eqIndex = url.indexOf('=');
+  const colonIndex = url.indexOf(':');
+  if (eqIndex !== -1 && (colonIndex === -1 || eqIndex < colonIndex)) {
+    const candidate = url.slice(eqIndex + 1).trim();
+    const candidateProbe = candidate.replace(/^[^A-Za-z]+/, '');
+    if (/^[A-Za-z][A-Za-z0-9+.-]*:/.test(candidateProbe)) {
+      url = candidate;
+    }
+  }
+
   // Copy/paste can introduce invisible characters (for example zero-width spaces) or
   // escaped quoting (`\"...\"`) that break simple protocol checks.
   url = url.replace(/^[^A-Za-z]+/, '');


### PR DESCRIPTION
Autonomous GTM workflows were falling back to sqlite with , which indicates DATABASE_URL isn't parsing as a URL scheme.\n\nThis adds a small normalization step that strips a leading  prefix (e.g. ) when it appears before the first ':' so Postgres detection works reliably.