### PR TITLE
Fix Actions warning: add .gitmodules for qmd-skill submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "projects/qmd-skill"]
+	path = projects/qmd-skill
+	url = https://github.com/levineam/qmd-skill.git


### PR DESCRIPTION
GitHub Actions post-checkout emits: "No url found for submodule path 'projects/qmd-skill' in .gitmodules".\n\nThis adds a minimal .gitmodules entry so git can resolve the submodule metadata cleanly.