### PR TITLE
CI: skip X traction in keep-going

### DIFF
--- a/.github/workflows/gtm-keep-going.yml
+++ b/.github/workflows/gtm-keep-going.yml
@@ -43,6 +43,7 @@ jobs:
           GTM_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GTM_KEEP_GOING_MAX_RUNS: "1"
           GTM_KEEP_GOING_RUN_MONITOR: "true"
+          GTM_KEEP_GOING_RUN_X_TRACTION: "false"
           GTM_KEEP_GOING_SOCIAL_EXECUTE: "true"
           GTM_REPORT_DIR: reports/gtm
         run: npm run gtm:keep-going


### PR DESCRIPTION
The keep-going workflow runs on ubuntu runners where the `bird` CLI is not installed and X cookies are not available, so the X traction step always fails noisily.

This disables X traction in the CI keep-going loop by default (it should be run locally via `npm run x:traction:local` instead).